### PR TITLE
Convert server to be exposed over RPC

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,6 @@
       new server if it has not heard from a server for 2s/3 ms,
       where s is the session timeout in milliseconds.
   - Implement ephemeral ZNodes (can't have children)
-  - Set up a way to run integration tests
 - Add an async version of the server
   - Maybe just have an async client that calls each method in a goroutine?
   - For FIFO client order we can use channels to implement this. And use blocking vs non-blocking channels for implementing sync / async
@@ -22,5 +21,4 @@
   - Use two-phase commit for replication
   - Implement atomic broadcast (ZAB)
 - Split Zookeeper into a multiple processes
-  - Update Zookeeper executables to be a separate client/server
-  - Expose via localhost over RPC / HTTP
+  - Set up a way to run integration tests

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/rpc"
+
+	"github.com/mikekulinski/zookeeper/pkg/server"
+)
+
+const (
+	serverAddress = "localhost"
+)
+
+func main() {
+	client, err := rpc.DialHTTP("tcp", serverAddress+":8080")
+	if err != nil {
+		log.Fatal("dialing:", err)
+	}
+
+	// Synchronous call
+	req := &server.CreateReq{
+		Path:  "/x/p",
+		Data:  []byte("Hello World!"),
+		Flags: []server.Flag{server.SEQUENTIAL},
+	}
+	reply := &server.CreateResp{}
+	err = client.Call("Server.Create", req, reply)
+	if err != nil {
+		log.Fatal("server error:", err)
+	}
+	fmt.Println(reply.ZNodeName)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("Hello World!")
-}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"net/rpc"
+
+	"github.com/mikekulinski/zookeeper/pkg/server"
+)
+
+func main() {
+	zk := server.NewServer()
+	err := rpc.Register(zk)
+	if err != nil {
+		log.Fatal("register error:", err)
+	}
+	rpc.HandleHTTP()
+	l, err := net.Listen("tcp", ":8080")
+	if err != nil {
+		log.Fatal("listen error:", err)
+	}
+	err = http.Serve(l, nil)
+	if err != nil {
+		log.Fatal("serve error:", err)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,7 +16,7 @@ type Zookeeper interface {
 	Delete(req *DeleteReq, resp *DeleteResp) error
 	// Exists returns true if the ZNode with path name path exists, and returns false otherwise. The watch flag
 	// enables a client to set a watch on the ZNode.
-	Exists(path string, watch bool) (exists bool, err error)
+	Exists(req *ExistsReq, resp *ExistsResp) error
 	// GetData returns the data and metadata, such as version information, associated with the ZNode.
 	// The watch flag works in the same way as it does for exists(), except that ZooKeeper does not set the watch
 	// if the ZNode does not exist.
@@ -115,16 +115,18 @@ func (s *Server) Delete(req *DeleteReq, _ *DeleteResp) error {
 	return nil
 }
 
-func (s *Server) Exists(path string, watch bool) (bool, error) {
-	err := validatePath(path)
+func (s *Server) Exists(req *ExistsReq, resp *ExistsResp) error {
+	err := validatePath(req.Path)
 	if err != nil {
-		return false, err
+		return err
 	}
-	names := splitPathIntoNodeNames(path)
+	names := splitPathIntoNodeNames(req.Path)
 
 	node := findZNode(s.root, names)
 	// TODO: Implement watching mechanism.
-	return node != nil, nil
+	// Set the response and return.
+	resp.Exists = node != nil
+	return nil
 }
 
 func (s *Server) GetData(path string, watch bool) ([]byte, int, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -28,7 +28,7 @@ type Zookeeper interface {
 	GetChildren(req *GetChildrenReq, resp *GetChildrenResp) error
 	// Sync waits for all updates pending at the start of the operation to propagate to the server
 	// that the client is connected to. The path is currently ignored. (Using path is not discussed in the white paper)
-	Sync(path string)
+	Sync(req *SyncReq, resp *SyncResp) error
 }
 
 type Server struct {
@@ -190,8 +190,8 @@ func (s *Server) GetChildren(req *GetChildrenReq, resp *GetChildrenResp) error {
 	return nil
 }
 
-func (s *Server) Sync(_ string) {
-
+func (s *Server) Sync(_ *SyncReq, _ *SyncResp) error {
+	return fmt.Errorf("not implemented")
 }
 
 func splitPathIntoNodeNames(path string) []string {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,7 +23,7 @@ type Zookeeper interface {
 	GetData(req *GetDataReq, resp *GetDataResp) error
 	// SetData writes data to the ZNode path if the version number is the current version of the ZNode.
 	// TODO: What do we do if the version is invalid? Should we return some sort of error message?
-	SetData(path string, data []byte, version int) error
+	SetData(req *SetDataReq, resp *SetDataResp) error
 	// GetChildren returns the set of names of the children of a ZNode.
 	GetChildren(path string, watch bool) (childrenNames []string, err error)
 	// Sync waits for all updates pending at the start of the operation to propagate to the server
@@ -148,21 +148,21 @@ func (s *Server) GetData(req *GetDataReq, resp *GetDataResp) error {
 	return nil
 }
 
-func (s *Server) SetData(path string, data []byte, version int) error {
-	err := validatePath(path)
+func (s *Server) SetData(req *SetDataReq, _ *SetDataResp) error {
+	err := validatePath(req.Path)
 	if err != nil {
 		return err
 	}
-	names := splitPathIntoNodeNames(path)
+	names := splitPathIntoNodeNames(req.Path)
 
 	node := findZNode(s.root, names)
 	if node == nil {
 		return fmt.Errorf("node does not exist")
 	}
-	if !isValidVersion(version, node.Version) {
-		return fmt.Errorf("invalid version: expected [%d], actual [%d]", version, node.Version)
+	if !isValidVersion(req.Version, node.Version) {
+		return fmt.Errorf("invalid version: expected [%d], actual [%d]", req.Version, node.Version)
 	}
-	node.Data = data
+	node.Data = req.Data
 	node.Version++
 	return nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -185,18 +185,22 @@ func TestServer_Delete(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			zk := NewServer()
-			req := &CreateReq{
+			cReq := &CreateReq{
 				Path: "/" + rootChildName,
 			}
-			err := zk.Create(req, &CreateResp{})
+			err := zk.Create(cReq, &CreateResp{})
 			require.NoError(t, err)
-			req = &CreateReq{
+			cReq = &CreateReq{
 				Path: fmt.Sprintf("/%s/%s", rootChildName, childChildName),
 			}
-			err = zk.Create(req, &CreateResp{})
+			err = zk.Create(cReq, &CreateResp{})
 			require.NoError(t, err)
 
-			err = zk.Delete(test.path, test.version)
+			dReq := &DeleteReq{
+				Path:    test.path,
+				Version: test.version,
+			}
+			err = zk.Delete(dReq, &DeleteResp{})
 			if test.errorExpected {
 				assert.Error(t, err)
 			} else {
@@ -300,20 +304,29 @@ func TestServer_Exists_NodeCreatedThenDeleted(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			zk := NewServer()
 			// Create nodes to check for.
-			req := &CreateReq{
+			cReq := &CreateReq{
 				Path: "/" + rootChildName,
 			}
-			err := zk.Create(req, &CreateResp{})
+			err := zk.Create(cReq, &CreateResp{})
 			require.NoError(t, err)
-			req = &CreateReq{
+			cReq = &CreateReq{
 				Path: fmt.Sprintf("/%s/%s", rootChildName, childChildName),
 			}
-			err = zk.Create(req, &CreateResp{})
+			err = zk.Create(cReq, &CreateResp{})
 			require.NoError(t, err)
+
 			// Delete all those nodes to verify we deleted them.
-			err = zk.Delete(fmt.Sprintf("/%s/%s", rootChildName, childChildName), -1)
+			dReq := &DeleteReq{
+				Path:    fmt.Sprintf("/%s/%s", rootChildName, childChildName),
+				Version: -1,
+			}
+			err = zk.Delete(dReq, &DeleteResp{})
 			require.NoError(t, err)
-			err = zk.Delete("/"+rootChildName, -1)
+			dReq = &DeleteReq{
+				Path:    "/" + rootChildName,
+				Version: -1,
+			}
+			err = zk.Delete(dReq, &DeleteResp{})
 			require.NoError(t, err)
 
 			exists, err := zk.Exists(test.path, false)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -58,7 +58,11 @@ func TestServer_Create(t *testing.T) {
 				existingNodeName: znode.NewZNode(existingNodeName, 0, test.parentNodeType, nil),
 			}
 
-			_, err := zk.Create(test.path, nil)
+			req := &CreateReq{
+				Path: test.path,
+			}
+			resp := &CreateResp{}
+			err := zk.Create(req, resp)
 			if test.errorExpected {
 				assert.Error(t, err)
 			} else {
@@ -109,12 +113,17 @@ func TestServer_Create_Sequential(t *testing.T) {
 				existingNodeName: existingNode,
 			}
 
-			actualName, err := zk.Create(test.path, nil, SEQUENTIAL)
+			req := &CreateReq{
+				Path:  test.path,
+				Flags: []Flag{SEQUENTIAL},
+			}
+			resp := &CreateResp{}
+			err := zk.Create(req, resp)
 			if test.errorExpected {
-				assert.Empty(t, actualName)
+				assert.Empty(t, resp.ZNodeName)
 				assert.Error(t, err)
 			} else {
-				assert.Equal(t, "new_5", actualName)
+				assert.Equal(t, "new_5", resp.ZNodeName)
 				assert.NoError(t, err)
 			}
 		})
@@ -176,9 +185,15 @@ func TestServer_Delete(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			zk := NewServer()
-			_, err := zk.Create("/"+rootChildName, nil)
+			req := &CreateReq{
+				Path: "/" + rootChildName,
+			}
+			err := zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
-			_, err = zk.Create(fmt.Sprintf("/%s/%s", rootChildName, childChildName), nil)
+			req = &CreateReq{
+				Path: fmt.Sprintf("/%s/%s", rootChildName, childChildName),
+			}
+			err = zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
 
 			err = zk.Delete(test.path, test.version)
@@ -239,9 +254,15 @@ func TestServer_Exists_NodeCreated(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			zk := NewServer()
-			_, err := zk.Create("/"+rootChildName, nil)
+			req := &CreateReq{
+				Path: "/" + rootChildName,
+			}
+			err := zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
-			_, err = zk.Create(fmt.Sprintf("/%s/%s", rootChildName, childChildName), nil)
+			req = &CreateReq{
+				Path: fmt.Sprintf("/%s/%s", rootChildName, childChildName),
+			}
+			err = zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
 
 			exists, err := zk.Exists(test.path, false)
@@ -279,9 +300,15 @@ func TestServer_Exists_NodeCreatedThenDeleted(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			zk := NewServer()
 			// Create nodes to check for.
-			_, err := zk.Create("/"+rootChildName, nil)
+			req := &CreateReq{
+				Path: "/" + rootChildName,
+			}
+			err := zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
-			_, err = zk.Create(fmt.Sprintf("/%s/%s", rootChildName, childChildName), nil)
+			req = &CreateReq{
+				Path: fmt.Sprintf("/%s/%s", rootChildName, childChildName),
+			}
+			err = zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
 			// Delete all those nodes to verify we deleted them.
 			err = zk.Delete(fmt.Sprintf("/%s/%s", rootChildName, childChildName), -1)
@@ -343,9 +370,18 @@ func TestServer_GetData(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			zk := NewServer()
-			_, err := zk.Create("/"+rootChildName, test.data)
+			req := &CreateReq{
+				Path: "/" + rootChildName,
+				Data: test.data,
+			}
+			err := zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
-			_, err = zk.Create(fmt.Sprintf("/%s/%s", rootChildName, childChildName), test.data)
+			req = &CreateReq{
+				Path: fmt.Sprintf("/%s/%s", rootChildName, childChildName),
+				Data: test.data,
+			}
+			err = zk.Create(req, &CreateResp{})
+			require.NoError(t, err)
 			require.NoError(t, err)
 
 			// Set the versions on the nodes so we can differentiate between missing nodes and nodes that exists but
@@ -426,9 +462,15 @@ func TestServer_SetData(t *testing.T) {
 			dataToSet := []byte("you're a wizard Harry")
 
 			zk := NewServer()
-			_, err := zk.Create("/"+rootChildName, nil)
+			req := &CreateReq{
+				Path: "/" + rootChildName,
+			}
+			err := zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
-			_, err = zk.Create(fmt.Sprintf("/%s/%s", rootChildName, childChildName), nil)
+			req = &CreateReq{
+				Path: fmt.Sprintf("/%s/%s", rootChildName, childChildName),
+			}
+			err = zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
 
 			err = zk.SetData(test.path, dataToSet, test.version)
@@ -492,9 +534,15 @@ func TestServer_GetChildren(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			zk := NewServer()
-			_, err := zk.Create("/"+rootChildName, nil)
+			req := &CreateReq{
+				Path: "/" + rootChildName,
+			}
+			err := zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
-			_, err = zk.Create(fmt.Sprintf("/%s/%s", rootChildName, childChildName), nil)
+			req = &CreateReq{
+				Path: fmt.Sprintf("/%s/%s", rootChildName, childChildName),
+			}
+			err = zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
 
 			// Set the versions on the nodes so we can differentiate between missing nodes and nodes that exists but

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -269,12 +269,16 @@ func TestServer_Exists_NodeCreated(t *testing.T) {
 			err = zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
 
-			exists, err := zk.Exists(test.path, false)
+			eReq := &ExistsReq{
+				Path: test.path,
+			}
+			eResp := &ExistsResp{}
+			err = zk.Exists(eReq, eResp)
 			if test.errorExpected {
-				assert.False(t, exists)
+				assert.False(t, eResp.Exists)
 				assert.Error(t, err)
 			} else {
-				assert.Equal(t, test.exists, exists)
+				assert.Equal(t, test.exists, eResp.Exists)
 				assert.NoError(t, err)
 			}
 		})
@@ -329,8 +333,12 @@ func TestServer_Exists_NodeCreatedThenDeleted(t *testing.T) {
 			err = zk.Delete(dReq, &DeleteResp{})
 			require.NoError(t, err)
 
-			exists, err := zk.Exists(test.path, false)
-			assert.Equal(t, test.exists, exists)
+			eReq := &ExistsReq{
+				Path: test.path,
+			}
+			eResp := &ExistsResp{}
+			err = zk.Exists(eReq, eResp)
+			assert.Equal(t, test.exists, eResp.Exists)
 			assert.NoError(t, err)
 		})
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -586,12 +586,16 @@ func TestServer_GetChildren(t *testing.T) {
 			rootChild.Version = 5
 			rootChild.Children[childChildName].Version = 5
 
-			children, err := zk.GetChildren(test.path, false)
+			cReq := &GetChildrenReq{
+				Path: test.path,
+			}
+			cResp := &GetChildrenResp{}
+			err = zk.GetChildren(cReq, cResp)
 			if test.errorExpected {
-				assert.Empty(t, children)
+				assert.Empty(t, cResp.Children)
 				assert.Error(t, err)
 			} else {
-				assert.Equal(t, test.children, children)
+				assert.Equal(t, test.children, cResp.Children)
 				assert.NoError(t, err)
 			}
 		})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -411,14 +411,18 @@ func TestServer_GetData(t *testing.T) {
 			rootChild.Version = test.version
 			rootChild.Children[childChildName].Version = test.version
 
-			data, version, err := zk.GetData(test.path, false)
+			gReq := &GetDataReq{
+				Path: test.path,
+			}
+			gResp := &GetDataResp{}
+			err = zk.GetData(gReq, gResp)
 			if test.errorExpected {
-				assert.Empty(t, data)
-				assert.Zero(t, version)
+				assert.Empty(t, gResp.Data)
+				assert.Zero(t, gResp.Version)
 				assert.Error(t, err)
 			} else {
-				assert.Equal(t, test.data, data)
-				assert.Empty(t, test.version, version)
+				assert.Equal(t, test.data, gResp.Data)
+				assert.Empty(t, test.version, gResp.Version)
 				assert.NoError(t, err)
 			}
 		})
@@ -502,10 +506,14 @@ func TestServer_SetData(t *testing.T) {
 			}
 
 			if test.writeSucceeds {
-				data, version, err := zk.GetData(test.path, false)
-				assert.Equal(t, dataToSet, data)
+				gReq := &GetDataReq{
+					Path: test.path,
+				}
+				gResp := &GetDataResp{}
+				err := zk.GetData(gReq, gResp)
+				assert.Equal(t, dataToSet, gResp.Data)
 				// We expect the set to increment the version.
-				assert.Equal(t, 1, version)
+				assert.Equal(t, 1, gResp.Version)
 				assert.NoError(t, err)
 			}
 		})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -498,7 +498,13 @@ func TestServer_SetData(t *testing.T) {
 			err = zk.Create(req, &CreateResp{})
 			require.NoError(t, err)
 
-			err = zk.SetData(test.path, dataToSet, test.version)
+			sReq := &SetDataReq{
+				Path:    test.path,
+				Data:    dataToSet,
+				Version: test.version,
+			}
+			sResp := &SetDataResp{}
+			err = zk.SetData(sReq, sResp)
 			if test.errorExpected {
 				assert.Error(t, err)
 			} else {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -62,7 +62,7 @@ type GetChildrenReq struct {
 }
 
 type GetChildrenResp struct {
-	ChildrenNames []string
+	Children []string
 }
 
 type SyncReq struct {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -1,0 +1,72 @@
+package server
+
+// TODO: Add comments for this whole file.
+type Flag int
+
+const (
+	// EPHEMERAL indicates that the ZNode to be created should be automatically destroyed once the session
+	// has been terminated (either intentionally or on failure).
+	EPHEMERAL Flag = iota
+	// SEQUENTIAL indicates that the node to be created should have a monotonically increasing counter appended
+	// to the end of the provided name.
+	SEQUENTIAL
+)
+
+type CreateReq struct {
+	Path  string
+	Data  []byte
+	Flags []Flag
+}
+
+type CreateResp struct {
+	ZNodeName string
+}
+
+type DeleteReq struct {
+	Path    string
+	Version int
+}
+
+type DeleteResp struct{}
+
+type ExistsReq struct {
+	Path  string
+	Watch bool
+}
+
+type ExistsResp struct {
+	Exists bool
+}
+
+type GetDataReq struct {
+	Path  string
+	Watch bool
+}
+
+type GetDataResp struct {
+	Data    []byte
+	Version int
+}
+
+type SetDataReq struct {
+	Path    string
+	Data    []byte
+	Version int
+}
+
+type SetDataResp struct{}
+
+type GetChildrenReq struct {
+	Path  string
+	Watch bool
+}
+
+type GetChildrenResp struct {
+	ChildrenNames []string
+}
+
+type SyncReq struct {
+	Path string
+}
+
+type SyncResp struct{}


### PR DESCRIPTION
**Background**
In order to actually use this on multiple processes, I'd like to expose this over RPC so we can make the API calls.

**Changes**
- Added types for each request and response
- Converted the signature of all the API endpoints to follow the required pattern for RPC https://pkg.go.dev/net/rpc
- Added client and server executables so we can run this and test them out interactively

**Testing**
- Verified we can send commands to the server over RPC and we get the responses we expect
- Updated the unit tests to test with the new endpoint format